### PR TITLE
Replace "==" with "="

### DIFF
--- a/git-prune.plugin.zsh
+++ b/git-prune.plugin.zsh
@@ -78,7 +78,7 @@ should be removed from the repository.
     local_branches=$(git branch --merged "$branch_to_compare" | grep -v 'master$'  | grep -v 'release' | grep -v "develop$" | grep -v "staging" | grep -v "$branch_to_compare$")
 
     echo "Current branch: $branch_to_compare"
-    if  ($isBoth && [ -z "$remote_branches" ] && [ -z "$local_branches" ]) || ([ -z "$remote_branches" ] && $isRemote) || ([ -z "$local_branches" ] && ! [ $isBoth == true ] && ! [ $isRemote == true ]); then
+    if  ($isBoth && [ -z "$remote_branches" ] && [ -z "$local_branches" ]) || ([ -z "$remote_branches" ] && $isRemote) || ([ -z "$local_branches" ] && ! [ $isBoth = true ] && ! [ $isRemote = true ]); then
       echo "There aren't any new merged branches into $branch_to_compare"
     else
       if $isRemote; then


### PR DESCRIPTION
This makes it work with zsh on my machine (`zsh 5.7.1 (x86_64-apple-darwin18.2.0)`).

I'm using zplugin, with this ice modifier:

```
zplugin ice atclone'sed 's/==/=/g' git-prune.plugin.zsh > git-prune.zsh' \
    atpull'%atclone' src'git-prune.zsh'
zplugin light diazod/git-prune
```

And it works perfectly.